### PR TITLE
split test running and benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
         with:
           python-version: '3.9'
       - run: pip install riot==0.4
-      - run: riot -v run black --check .
+      - run: riot -v run -s black -- --check .
   test:
     strategy:
       matrix:

--- a/riotfile.py
+++ b/riotfile.py
@@ -9,14 +9,25 @@ venv = Venv(
                 3.8,
                 3.9,
             ],
-            name="test",
-            command="pytest {cmdargs}",
             pkgs={
+                "pytest": latest,
                 "pytest-benchmark": latest,
             },
+            venvs=[
+                Venv(
+                    name="test",
+                    command="pytest --benchmark-disable {cmdargs}",
+                ),
+                Venv(
+                    name="bench",
+                    command="pytest --benchmark-group-by=param {cmdargs}",
+                ),
+            ],
         ),
         Venv(
-            name="fmt",
+            pkgs={
+                "black": "==20.8b1",
+            },
             venvs=[
                 Venv(
                     name="black",

--- a/test_fassst.py
+++ b/test_fassst.py
@@ -63,16 +63,19 @@ def local_value_list_loop():
     return x
 
 
+test_fns = [
+    range_loop,
+    enumerate_loop,
+    list_str_loop,
+    list_int_loop,
+    class_loop,
+    local_value_list_loop,
+]
+
+
 @pytest.mark.parametrize(
     "fn",
-    [
-        range_loop,
-        enumerate_loop,
-        list_str_loop,
-        list_int_loop,
-        class_loop,
-        local_value_list_loop,
-    ],
+    test_fns,
 )
 def test_original(benchmark, fn):
     result = benchmark(fn)
@@ -80,14 +83,7 @@ def test_original(benchmark, fn):
 
 @pytest.mark.parametrize(
     "fn",
-    [
-        range_loop,
-        enumerate_loop,
-        list_str_loop,
-        list_int_loop,
-        class_loop,
-        local_value_list_loop,
-    ],
+    test_fns,
 )
 def test_fast(benchmark, fn):
     result = benchmark(fast(fn))


### PR DESCRIPTION
`riot run -s test` now runs the tests
`riot run -s bench` runs the benchmarks (grouped by test param)