### PR TITLE
Handle break and continue

### DIFF
--- a/fassst.py
+++ b/fassst.py
@@ -101,7 +101,12 @@ class InlineFor(ast.NodeTransformer):
             new_body.append(
                 ast.copy_location(ast.Assign(targets=[node.target], value=x), node)
             )
-            new_body.extend([self.visit(n) for n in node.body])
+            for n in node.body:
+                new_n = self.visit(n)
+                if isinstance(new_n, list):
+                    new_body.extend(new_n)
+                else:
+                    new_body.append(new_n)
             new_body.append(make_placeholder("iteration_end", loop_id, i))
         new_body.append(make_placeholder("loop_end", loop_id))
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license="Apache 2",
     py_modules=["fassst"],
     python_requires=">=3.8",
-    install_requires=[],
+    install_requires=["bytecode>=0.11.0"],
     setup_requires=["setuptools_scm"],
     use_scm_version=True,
 )

--- a/test_fassst.py
+++ b/test_fassst.py
@@ -63,6 +63,26 @@ def local_value_list_loop():
     return x
 
 
+def break_continue():
+    ns = []
+    for i in range(10):
+        if i == 0:
+            continue
+        if i == 4:
+            break
+        ns.append(i)
+    return ns
+
+
+def multiple_loops():
+    n = 0
+    for i in range(3):
+        n += 1
+    for i in range(4):
+        n += 2
+    return n
+
+
 test_fns = [
     range_loop,
     enumerate_loop,
@@ -70,6 +90,8 @@ test_fns = [
     list_int_loop,
     class_loop,
     local_value_list_loop,
+    break_continue,
+    multiple_loops,
 ]
 
 

--- a/test_fassst.py
+++ b/test_fassst.py
@@ -95,6 +95,15 @@ def nested_loops():
     return n
 
 
+def while_loop():
+    n = 0
+    for i in range(1):
+        while True:
+            break
+        n += 1
+    return n
+
+
 test_fns = [
     range_loop,
     enumerate_loop,
@@ -105,6 +114,7 @@ test_fns = [
     break_continue,
     multiple_loops,
     nested_loops,
+    while_loop,
 ]
 
 

--- a/test_fassst.py
+++ b/test_fassst.py
@@ -83,6 +83,18 @@ def multiple_loops():
     return n
 
 
+def nested_loops():
+    n = 0
+    for i in range(3):
+        if i == 1:
+            break
+        for i in range(5):
+            n += 3
+            if i == 3:
+                continue
+    return n
+
+
 test_fns = [
     range_loop,
     enumerate_loop,
@@ -92,6 +104,7 @@ test_fns = [
     local_value_list_loop,
     break_continue,
     multiple_loops,
+    nested_loops,
 ]
 
 


### PR DESCRIPTION
The idea here is to add placeholders to some key places:
- `break` statements
- `continue` statements
- the end of each unrolled iteration
- the end of each loop

With these placeholders (which are actually expression statements that try to resolve invalid identifiers), we can add labels to the bytecode to allow for jumping around.

Since the placeholders compile to 2 bytecode instructions (a `LOAD_GLOBAL` and `POP_TOP` since the expression is unused), we need to replace the second one of the two with a `NOP` instruction so it does nothing.

I added a dependency to make messing with the bytecode easier. It handles all the label resolution, and also comes with a peephole optimizer, which is used here mainly to get rid of the `NOP` instructions.